### PR TITLE
Support new macOS 10.12.1/iOS 10.1 features

### DIFF
--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -142,7 +142,7 @@
                 Used to render the Apple Pay button, which is shown if the
                 JavaScript determines that Apple Pay is available for use.
             *@
-            <div id="apple-pay-button" class="apple-pay apple-pay-button apple-pay-button-black input-block-level hide"></div>
+            <div id="apple-pay-button" class="apple-pay apple-pay-button-with-text apple-pay-button-black-with-text input-block-level hide"></div>
         </form>
     </div>
 </div>

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -133,10 +133,16 @@
                 </div>
             </fieldset>
             @*
+                Used to render the setup Apple Pay button, which is shown if the
+                JavaScript determines that Apple Pay is available, but there are
+                no payment cards set up in Wallet.
+            *@
+            <div id="set-up-apple-pay-button" class="apple-pay apple-pay-set-up-button apple-pay-set-up-button-black input-block-level hide"></div>
+            @*
                 Used to render the Apple Pay button, which is shown if the
                 JavaScript determines that Apple Pay is available for use.
             *@
-            <div class="apple-pay-button apple-pay-button-black input-block-level hide" />
+            <div id="apple-pay-button" class="apple-pay apple-pay-button apple-pay-button-black input-block-level hide"></div>
         </form>
     </div>
 </div>

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -148,7 +148,7 @@
                 Used to render the Apple Pay button, which is shown if the
                 JavaScript determines that Apple Pay is available for use.
             *@
-            <div id="apple-pay-button" class="apple-pay apple-pay-button-with-text apple-pay-button-black-with-text input-block-level hide"></div>
+            <div id="apple-pay-button" class="apple-pay input-block-level hide"></div>
         </form>
     </div>
 </div>

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -8,6 +8,12 @@
 @{
     ViewData["Title"] = "Sample integration";
     var token = Antiforgery.GetAndStoreTokens(Context);
+
+    var region = new System.Globalization.RegionInfo("en-GB");
+
+    var countryCode = region.TwoLetterISORegionName;
+    var currencyCode = region.ISOCurrencySymbol;
+    var currencySymbol = region.CurrencySymbol;
 }
 
 @section meta {
@@ -20,8 +26,8 @@
         Add meta tags for Apple Pay discoverability by web crawlers.
     *@
     <meta property="product:payment_method" content="ApplePay" />
-    <meta name="payment-country-code" content="GB" />
-    <meta name="payment-currency-code" content="GBP" />
+    <meta name="payment-country-code" content="@countryCode" />
+    <meta name="payment-currency-code" content="@currencyCode" />
     @*
         Add meta tags for use by the JavaScript to access the merchant identifier and store name.
     *@
@@ -113,12 +119,12 @@
         </div>
         <form>
             <fieldset class="form-group">
-                <label class="sr-only" for="amount">Amount (in GBP)</label>
+                <label class="sr-only" for="amount">Amount (in @currencyCode)</label>
                 <div class="input-group input-group-lg">
                     @*
                         Add a number input for the amount to charge in the Apple Pay Sheet.
                     *@
-                    <span class="input-group-addon" id="amount-addon">£</span>
+                    <span class="input-group-addon" id="amount-addon">@currencySymbol</span>
                     <input type="number"
                            aria-describedby="amount-addon"
                            autocomplete="off"

--- a/src/ApplePayJS/Views/Shared/_Layout.cshtml
+++ b/src/ApplePayJS/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
     Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 *@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="@(Context.Request.Query["lang"].FirstOrDefault() ?? "en")">
 <head>
     <title>@ViewData["Title"] - Apple Pay JS</title>
     <meta charset="utf-8" />

--- a/src/ApplePayJS/wwwroot/css/site.css
+++ b/src/ApplePayJS/wwwroot/css/site.css
@@ -20,37 +20,137 @@ textarea {
     max-width: 280px;
 }
 
-div.apple-pay-button {
+div.apple-pay {
     max-width: 325px;
     width: 100%;
     height: 46px;
 }
 
-.apple-pay-button {
+@supports (-webkit-appearance: -apple-pay-button) {
+    .apple-pay-button {
+        display: inline-block;
+        -webkit-appearance: -apple-pay-button;
+    }
+    .apple-pay-button-black {
+        -apple-pay-button-style: black;
+    }
+    .apple-pay-button-white {
+        -apple-pay-button-style: white;
+    }
+    .apple-pay-button-white-with-line {
+        -apple-pay-button-style: white-outline;
+    }
+    .apple-pay-button-with-text {
+        display: inline-block;
+        -webkit-appearance: -apple-pay-button;
+        -apple-pay-button-type: buy;
+    }
+    .apple-pay-button-with-text > * {
+        display: none;
+    }
+    .apple-pay-button-black-with-text {
+        -apple-pay-button-style: black;
+    }
+    .apple-pay-button-white-with-text {
+        -apple-pay-button-style: white;
+    }
+    .apple-pay-button-white-with-line-with-text {
+        -apple-pay-button-style: white-outline;
+    }
+}
+
+@supports not (-webkit-appearance: -apple-pay-button) {
+    .apple-pay-button {
+        display: inline-block;
+        background-size: 100% 60%;
+        background-repeat: no-repeat;
+        background-position: 50% 50%;
+        border-radius: 5px;
+        padding: 0px;
+        box-sizing: border-box;
+        min-width: 200px;
+        min-height: 32px;
+        max-height: 64px;
+    }
+    .apple-pay-button-black {
+        background-image: -webkit-named-image(apple-pay-logo-white);
+        background-color: black;
+    }
+    .apple-pay-button-white {
+        background-image: -webkit-named-image(apple-pay-logo-black);
+        background-color: white;
+    }
+    .apple-pay-button-white-with-line {
+        background-image: -webkit-named-image(apple-pay-logo-black);
+        background-color: white;
+        border: .5px solid black;
+    }
+    .apple-pay-button-with-text {
+        --apple-pay-scale: 1; /* (height / 32) */
+        display: inline-flex;
+        justify-content: center;
+        font-size: 12px;
+        border-radius: 5px;
+        padding: 0px;
+        box-sizing: border-box;
+        min-width: 200px;
+        min-height: 32px;
+        max-height: 64px;
+    }
+    .apple-pay-button-black-with-text {
+        background-color: black;
+        color: white;
+    }
+    .apple-pay-button-white-with-text {
+        background-color: white;
+        color: black;
+    }
+    .apple-pay-button-white-with-line-with-text {
+        background-color: white;
+        color: black;
+        border: .5px solid black;
+    }
+    .apple-pay-button-with-text.apple-pay-button-black-with-text > .logo {
+        background-image: -webkit-named-image(apple-pay-logo-white);
+        background-color: black;
+    }
+    .apple-pay-button-with-text.apple-pay-button-white-with-text > .logo {
+        background-image: -webkit-named-image(apple-pay-logo-black);
+        background-color: white;
+    }
+    .apple-pay-button-with-text.apple-pay-button-white-with-line-with-text > .logo {
+        background-image: -webkit-named-image(apple-pay-logo-black);
+        background-color: white;
+    }
+    .apple-pay-button-with-text > .text {
+        font-family: -apple-system;
+        font-size: calc(1em * var(--apple-pay-scale));
+        font-weight: 300;
+        align-self: center;
+        margin-right: calc(2px * var(--apple-pay-scale));
+    }
+    .apple-pay-button-with-text > .logo {
+        width: calc(35px * var(--scale));
+        height: 100%;
+        background-size: 100% 60%;
+        background-repeat: no-repeat;
+        background-position: 0 50%;
+        margin-left: calc(2px * var(--apple-pay-scale));
+        border: none;
+    }
+}
+
+.apple-pay-set-up-button {
     display: inline-block;
-    background-size: 100% 60%;
-    background-repeat: no-repeat;
-    background-position: 50% 50%;
-    border-radius: 5px;
-    padding: 0;
-    box-sizing: border-box;
-    min-width: 200px;
-    min-height: 32px;
-    max-height: 64px;
+    -webkit-appearance: -apple-pay-button;
+    -apple-pay-button-type: set-up;
 }
-
-.apple-pay-button-black {
-    background-image: -webkit-named-image(apple-pay-logo-white);
-    background-color: black;
+.apple-pay-set-up-button-black {
+    -apple-pay-button-style: black;
 }
-
-.apple-pay-button-white {
-    background-image: -webkit-named-image(apple-pay-logo-black);
-    background-color: white;
+.apple-pay-set-up-button-white {
+    -apple-pay-button-style: white;
 }
-
-.apple-pay-button-white-with-line {
-    background-image: -webkit-named-image(apple-pay-logo-black);
-    background-color: white;
-    border: .5px solid black;
+.apple-pay-setup-button-white-with-line {
+    -apple-pay-button-style: white-outline;
 }

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -180,6 +180,15 @@ justEat = {
             var button = $("#apple-pay-button");
             button.attr("lang", justEat.applePay.getPageLanguage());
             button.on("click", justEat.applePay.beginPayment);
+
+            if (justEat.applePay.supportsSetup()) {
+                button.addClass("apple-pay-button-with-text");
+                button.addClass("apple-pay-button-black-with-text");
+            } else {
+                button.addClass("apple-pay-button");
+                button.addClass("apple-pay-button-black");
+            }
+
             button.removeClass("hide");
         },
         showSetupButton: function () {

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -178,11 +178,13 @@ justEat = {
         },
         showButton: function () {
             var button = $("#apple-pay-button");
+            button.attr("lang", justEat.applePay.getPageLanguage());
             button.on("click", justEat.applePay.beginPayment);
             button.removeClass("hide");
         },
         showSetupButton: function () {
             var button = $("#set-up-apple-pay-button");
+            button.attr("lang", justEat.applePay.getPageLanguage());
             button.on("click", justEat.applePay.setupApplePay);
             button.removeClass("hide");
         },
@@ -206,6 +208,9 @@ justEat = {
         },
         supportsSetup: function () {
             return "openPaymentSetup" in ApplePaySession;
+        },
+        getPageLanguage: function () {
+            return $("html").attr("lang") || "en";
         }
     }
 };


### PR DESCRIPTION
Update the Apple Pay JS sample to support the use of new features from macOS 10.12.1 and iOS 10.1, such as:
  1. Adding a "Set up Apple Pay" button if the user's device supports Apple Pay but has no cards in Wallet.
  1. Use new CSS properties to render the Apple Pay button in the required style ("plain", "buy with", "setup").
  1. Support localisation of the text on the Apple Pay button.