### PR TITLE
Improve certificate load error handling

### DIFF
--- a/src/ApplePayJS/Controllers/HomeController.cs
+++ b/src/ApplePayJS/Controllers/HomeController.cs
@@ -114,18 +114,33 @@ namespace JustEat.ApplePayJS.Controllers
                 {
                     store.Open(OpenFlags.ReadOnly);
 
-                    certificate = store.Certificates.Find(
+                    var certificates = store.Certificates.Find(
                         X509FindType.FindByThumbprint,
                         _options.MerchantCertificateThumbprint,
-                        validOnly: false)[0];
+                        validOnly: false);
+
+                    if (certificates.Count < 1)
+                    {
+                        throw new InvalidOperationException(
+                            $"Could not find Apple Pay merchant certificate with thumbprint '{_options.MerchantCertificateThumbprint}' from store '{store.Name}' in location '{store.Location}'.");
+                    }
+
+                    certificate = certificates[0];
                 }
             }
             else
             {
-                // Load the X.509 certificate from disk
-                certificate = new X509Certificate2(
-                    _options.MerchantCertificateFileName,
-                    _options.MerchantCertificatePassword);
+                try
+                {
+                    // Load the X.509 certificate from disk
+                    certificate = new X509Certificate2(
+                        _options.MerchantCertificateFileName,
+                        _options.MerchantCertificatePassword);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Failed to load Apple Pay merchant certificate file from '{_options.MerchantCertificateFileName}'.", ex);
+                }
             }
 
             return certificate;

--- a/src/ApplePayJS/Controllers/HomeController.cs
+++ b/src/ApplePayJS/Controllers/HomeController.cs
@@ -116,7 +116,7 @@ namespace JustEat.ApplePayJS.Controllers
 
                     var certificates = store.Certificates.Find(
                         X509FindType.FindByThumbprint,
-                        _options.MerchantCertificateThumbprint,
+                        _options.MerchantCertificateThumbprint?.Trim(),
                         validOnly: false);
 
                     if (certificates.Count < 1)


### PR DESCRIPTION
  1. Improve the handling of errors when loading the Apple Pay merchant certificate if it cannot be loaded from either the X.509 certificate store or from disk.
  1. Trim any extraneous whitespace from the configured Apple Pay merchant certificate thumbprint before attempting to load it.

Resolves #4.