### PR TITLE
Add TypeScript example and polyfill for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.DS_Store
+﻿.DS_Store
 .metadata
 .settings
 .vs
@@ -20,6 +20,7 @@ src/ApplePayJS/*.pfx
 src/ApplePayJS/wwwroot/.well-known/*
 src/ApplePayJS/wwwroot/**/*.min.css
 src/ApplePayJS/wwwroot/**/*.min.js
+src/ApplePayJS/wwwroot/ts/*.js
 src/ApplePayJS/wwwroot/lib/*
 TestResults
 UpgradeLog*.htm
@@ -28,6 +29,7 @@ PublishProfiles
 *.DotSettings
 *.GhostDoc.xml
 *.log
+*.map
 *.nupkg
 *.opensdf
 *.[Pp]ublish.xml

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To setup the repository to run the sample, perform the steps below:
   1. Install the [.NET Core 1.0.1 SDK](https://www.microsoft.com/net/download/core), Visual Studio 2017 or Visual Studio Code.
   1. Fork this repository.
   1. Clone the repository from your fork to your local machine: ```git clone https://github.com/{username}/ApplePayJSSample.git```
+  1. Restore the Bower, npm and NuGet packages.
   1. [Follow the steps](https://developer.apple.com/reference/applepayjs#2193397) to obtain your Apple Pay Merchant ID, Payment Processing Certificate, Domain Verification file and Merchant Identity Certificate if you do not already have them.
   1. Place the Domain Verification file (```apple-developer-merchantid-domain-association```) in the ```src\ApplePayJS\wwwroot\.well-known``` folder.
   1. Generate a ```.pfx``` file from your Merchant Identity Certificate (```merchant_id.cer```, which is the public key) and the Certificate Signing Request (```your_file_name.csr```, which is the private key) that you used to generate it.

--- a/src/ApplePayJS/ApplePayJS.csproj
+++ b/src/ApplePayJS/ApplePayJS.csproj
@@ -24,6 +24,7 @@
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="wwwroot\ts\**\*.ts" />
     <Content Update="appsettings.json;appsettings.*.json;web.config" CopyToPublishDirectory="PreserveNewest" />
     <Content Update="wwwroot\**\*;Views\**\*;Areas\**\Views" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="*.pfx" CopyToPublishDirectory="PreserveNewest" />
@@ -46,6 +47,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.0.1" />
   </ItemGroup>
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+    <Exec Command="npm run build" />
+    <Exec Command="npm run lint" />
     <Exec Command="dotnet bundle" />
   </Target>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" DependsOnTargets="PrepareForPublish">

--- a/src/ApplePayJS/Controllers/HomeController.cs
+++ b/src/ApplePayJS/Controllers/HomeController.cs
@@ -35,6 +35,7 @@ namespace JustEat.ApplePayJS.Controllers
 
         [HttpPost]
         [Produces("application/json")]
+        [Route("applepay/validate", Name = "MerchantValidation")]
         public async Task<IActionResult> Validate([FromBody] ValidateMerchantSessionModel model)
         {
             if (!ModelState.IsValid ||

--- a/src/ApplePayJS/Startup.cs
+++ b/src/ApplePayJS/Startup.cs
@@ -23,7 +23,7 @@ namespace JustEat.ApplePayJS
 
             if (env.IsDevelopment())
             {
-                builder.AddUserSecrets();
+                builder.AddUserSecrets<Startup>();
             }
 
             Configuration = builder.Build();

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -18,22 +18,31 @@
 }
 
 @section meta {
+
     @*
         Setup antiforgery tokens for the JavaScript.
     *@
     <meta name="x-antiforgery-name" content="@token.HeaderName" />
     <meta name="x-antiforgery-token" content="@token.RequestToken" />
+
     @*
         Add meta tags for Apple Pay discoverability by web crawlers.
     *@
     <meta property="product:payment_method" content="ApplePay" />
     <meta name="payment-country-code" content="@countryCode" />
     <meta name="payment-currency-code" content="@currencyCode" />
+
     @*
         Add meta tags for use by the JavaScript to access the merchant identifier and store name.
     *@
     <meta name="apple-pay-merchant-id" content="@ViewData["MerchantId"]" />
     <meta name="apple-pay-store-name" content="@ViewData["StoreName"]" />
+
+    @*
+        Add link for use by the JavaScript to get the URL to POST to for merchant validation.
+    *@
+    <link rel="merchant-validation" href="@Url.RouteUrl("MerchantValidation")" />
+
     @*
         Add link tags for the icon to display on a paired
         device when a payment is started from Safari on macOS.

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -163,7 +163,7 @@
     </div>
 </div>
 @section scripts {
-    @if (string.Equals(Config["UseTypeScript"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    @if (string.Equals(Config["ApplePay:UseTypeScript"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
     {
         <environment names="Development">
             <script src="~/ts/site.js" asp-append-version="true"></script>

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -15,6 +15,7 @@
     var countryCode = region.TwoLetterISORegionName;
     var currencyCode = region.ISOCurrencySymbol;
     var currencySymbol = region.CurrencySymbol;
+    var merchantId = @ViewData["MerchantId"];
 }
 
 @section meta {
@@ -35,7 +36,7 @@
     @*
         Add meta tags for use by the JavaScript to access the merchant identifier and store name.
     *@
-    <meta name="apple-pay-merchant-id" content="@ViewData["MerchantId"]" />
+    <meta name="apple-pay-merchant-id" content="@merchantId" />
     <meta name="apple-pay-store-name" content="@ViewData["StoreName"]" />
 
     @*
@@ -163,6 +164,10 @@
     </div>
 </div>
 @section scripts {
+    @if (string.Equals(Config["ApplePay:UsePolyfill"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    {
+        @await Html.PartialAsync("_Polyfill", merchantId)
+    }
     @if (string.Equals(Config["ApplePay:UseTypeScript"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
     {
         <environment names="Development">

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -4,6 +4,7 @@
 *@
 
 @inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
+@inject Microsoft.Extensions.Configuration.IConfiguration Config
 
 @{
     ViewData["Title"] = "Sample integration";
@@ -152,3 +153,23 @@
         </form>
     </div>
 </div>
+@section scripts {
+    @if (string.Equals(Config["UseTypeScript"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    {
+        <environment names="Development">
+            <script src="~/ts/site.js" asp-append-version="true"></script>
+        </environment>
+        <environment names="Staging,Production">
+            <script src="~/ts/site.min.js" asp-append-version="true"></script>
+        </environment>
+    }
+    else
+    {
+        <environment names="Development">
+            <script src="~/js/site.js" asp-append-version="true"></script>
+        </environment>
+        <environment names="Staging,Production">
+            <script src="~/js/site.min.js" asp-append-version="true"></script>
+        </environment>
+    }
+}

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -10,7 +10,8 @@
     ViewData["Title"] = "Sample integration";
     var token = Antiforgery.GetAndStoreTokens(Context);
 
-    var region = new System.Globalization.RegionInfo("en-GB");
+    var language = Context.Request.Query["lang"].FirstOrDefault() ?? "en-GB";
+    var region = new System.Globalization.RegionInfo(language);
 
     var countryCode = region.TwoLetterISORegionName;
     var currencyCode = region.ISOCurrencySymbol;

--- a/src/ApplePayJS/Views/Home/_Polyfill.cshtml
+++ b/src/ApplePayJS/Views/Home/_Polyfill.cshtml
@@ -1,0 +1,49 @@
+﻿@model string
+@*
+    Use this polyfill during development to test your Apple Pay JS implementation
+    on devices and browsers that do not natively support Apple Pay.
+*@
+<environment names="Development">
+    <script src="~/lib/applepayjs-polyfill/ApplePaySession.js"></script>
+    <script>
+
+        @* Set the merchant identifier to use *@
+        ApplePaySessionPolyfill.setMerchantIdentifier("@Model");
+
+        @* Create a dummy billing and shipping contact *@
+        var createContact = function () {
+            return {
+                emailAddress: "user@domain.com",
+                familyName: "Smith",
+                givenName: "John",
+                phoneNumber: "07777777777",
+                addressLines: ["Just Eat", "Fleet Place House", "2 Fleet Place"],
+                locality: "London",
+                administrativeArea: "",
+                postalCode: "EC4M 7RF",
+                country: "United Kingdom",
+                countryCode: "GB"
+            };
+        };
+
+        ApplePaySessionPolyfill.createBillingContact = createContact;
+        ApplePaySessionPolyfill.createShippingContact = createContact;
+
+        @*
+            Create a dummy payment token, or use one generated from a test
+            device or a test token made available by your payment provider.
+        *@
+        ApplePaySessionPolyfill.createPaymentToken = function (session) {
+            return {
+                paymentData: "SomeEncryptedPaymentData",
+                paymentMethod: {
+                    displayName: "American Express",
+                    network: "amex",
+                    type: "credit",
+                    paymentPass: null
+                },
+                transactionIdentifier: "@Guid.NewGuid().ToString()"
+            };
+        };
+    </script>
+</environment>

--- a/src/ApplePayJS/Views/Shared/_Layout.cshtml
+++ b/src/ApplePayJS/Views/Shared/_Layout.cshtml
@@ -50,13 +50,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.js" integrity="sha256-16cdPddA6VdVInumRGo6IbivbERE8p7CQR3HzTBuELA=" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    <environment names="Development">
-        <script src="~/js/site.js" asp-append-version="true"></script>
-    </environment>
-    <environment names="Staging,Production">
-        <script src="~/js/site.min.js" asp-append-version="true"></script>
-    </environment>
-
     @RenderSection("scripts", required: false)
 </body>
 </html>

--- a/src/ApplePayJS/appsettings.json
+++ b/src/ApplePayJS/appsettings.json
@@ -13,5 +13,6 @@
       "System": "Information",
       "Microsoft": "Information"
     }
-  }
+  },
+  "UseTypeScript": false
 }

--- a/src/ApplePayJS/appsettings.json
+++ b/src/ApplePayJS/appsettings.json
@@ -4,7 +4,8 @@
     "UseCertificateStore": false,
     "MerchantCertificateFileName": "",
     "MerchantCertificatePassword": "",
-    "MerchantCertificateThumbprint": ""
+    "MerchantCertificateThumbprint": "",
+    "UseTypeScript": false
   },
   "Logging": {
     "IncludeScopes": false,
@@ -13,6 +14,5 @@
       "System": "Information",
       "Microsoft": "Information"
     }
-  },
-  "UseTypeScript": false
+  }
 }

--- a/src/ApplePayJS/appsettings.json
+++ b/src/ApplePayJS/appsettings.json
@@ -5,6 +5,7 @@
     "MerchantCertificateFileName": "",
     "MerchantCertificatePassword": "",
     "MerchantCertificateThumbprint": "",
+    "UsePolyfill": false,
     "UseTypeScript": false
   },
   "Logging": {

--- a/src/ApplePayJS/bower.json
+++ b/src/ApplePayJS/bower.json
@@ -2,5 +2,6 @@
   "name": "justeatapplepayjs",
   "private": true,
   "dependencies": {
+    "applepayjs-polyfill": "2.0.0"
   }
 }

--- a/src/ApplePayJS/bundleconfig.json
+++ b/src/ApplePayJS/bundleconfig.json
@@ -14,6 +14,17 @@
       "enabled": true,
       "renameLocals": true
     },
+    "sourceMap": true
+  },
+  {
+    "outputFileName": "wwwroot/ts/site.min.js",
+    "inputFiles": [
+      "wwwroot/ts/site.js"
+    ],
+    "minify": {
+      "enabled": true,
+      "renameLocals": true
+    },
     "sourceMap": false
   }
 ]

--- a/src/ApplePayJS/package.json
+++ b/src/ApplePayJS/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.1",
   "devDependencies": {
+    "@types/applepayjs": "1.0.0",
     "@types/jquery": "2.0.41",
     "tslint": "4.5.1",
     "typescript": "2.2.1"

--- a/src/ApplePayJS/package.json
+++ b/src/ApplePayJS/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "justeatapplepayjs",
+  "private": true,
+  "version": "1.0.1",
+  "devDependencies": {
+    "@types/jquery": "2.0.41",
+    "tslint": "4.5.1",
+    "typescript": "2.2.1"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "tslint ./wwwroot/**/*.ts"
+  }
+}

--- a/src/ApplePayJS/tsconfig.json
+++ b/src/ApplePayJS/tsconfig.json
@@ -1,0 +1,15 @@
+﻿{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "inlineSourceMap": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noEmitOnError": true,
+    "removeComments": true,
+    "target": "es6"
+  },
+  "exclude": [
+    "node_modules",
+    "obj"
+  ]
+}

--- a/src/ApplePayJS/tsconfig.json
+++ b/src/ApplePayJS/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "es6"
   },
   "exclude": [
+    "bin",
     "node_modules",
     "obj"
   ]

--- a/src/ApplePayJS/tsconfig.json
+++ b/src/ApplePayJS/tsconfig.json
@@ -2,11 +2,13 @@
   "compileOnSave": true,
   "compilerOptions": {
     "inlineSourceMap": true,
+    "lib": [ "dom", "es6" ],
+    "module": "commonjs",
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noEmitOnError": true,
     "removeComments": true,
-    "target": "es6"
+    "target": "es5"
   },
   "exclude": [
     "bin",

--- a/src/ApplePayJS/tslint.json
+++ b/src/ApplePayJS/tslint.json
@@ -1,0 +1,35 @@
+﻿{
+  "rules": {
+    "class-name": true,
+    "comment-format": [ true, "check-space" ],
+    "indent": [ true, "spaces" ],
+    "no-duplicate-variable": true,
+    "no-eval": true,
+    "no-internal-module": true,
+    "no-trailing-whitespace": true,
+    "no-var-keyword": true,
+    "one-line": [ true, "check-open-brace", "check-whitespace" ],
+    "quotemark": [ true, "double" ],
+    "semicolon": [ "always" ],
+    "triple-equals": [ true, "allow-null-check" ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "variable-name": [ true, "ban-keywords" ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}

--- a/src/ApplePayJS/wwwroot/css/site.css
+++ b/src/ApplePayJS/wwwroot/css/site.css
@@ -154,3 +154,21 @@ div.apple-pay {
 .apple-pay-setup-button-white-with-line {
     -apple-pay-button-style: white-outline;
 }
+
+.apple-pay-donate-button {
+    display: inline-block;
+    -webkit-appearance: -apple-pay-button;
+    -apple-pay-button-type: donate;
+}
+
+.apple-pay-donate-button-black {
+    -apple-pay-button-style: black;
+}
+
+.apple-pay-donate-button-white {
+    -apple-pay-button-style: white;
+}
+
+.apple-pay-donate-button-white-with-line {
+    -apple-pay-button-style: white-outline;
+}

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -72,7 +72,7 @@ justEat = {
                 // Post the payload to the server to validate the
                 // merchant session using the merchant certificate.
                 $.ajax({
-                    url: "/home/validate",
+                    url: $("link[rel='merchant-validation']").attr("href"),
                     method: "POST",
                     contentType: "application/json; charset=utf-8",
                     data: JSON.stringify(data),

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -163,7 +163,8 @@ justEat = {
             // Start the session to display the Apple Pay sheet.
             session.begin();
         },
-        setupApplePay: function (merchantIdentifier) {
+        setupApplePay: function () {
+            var merchantIdentifier = justEat.applePay.getMerchantIdentifier();
             ApplePaySession.openPaymentSetup(merchantIdentifier)
                 .then(function (success) {
                     if (success) {
@@ -194,7 +195,7 @@ justEat = {
         showSetupButton: function () {
             var button = $("#set-up-apple-pay-button");
             button.attr("lang", justEat.applePay.getPageLanguage());
-            button.on("click", justEat.applePay.setupApplePay);
+            button.on("click", $.proxy(justEat.applePay, "setupApplePay"));
             button.removeClass("hide");
         },
         hideSetupButton: function () {
@@ -220,6 +221,9 @@ justEat = {
         },
         getPageLanguage: function () {
             return $("html").attr("lang") || "en";
+        },
+        getMerchantIdentifier: function () {
+            return $("meta[name='apple-pay-merchant-id']").attr("content");
         }
     }
 };
@@ -230,7 +234,7 @@ justEat = {
     if (justEat.applePay.supportedByDevice()) {
 
         // Get the merchant identifier from the page meta tags.
-        var merchantIdentifier = $("meta[name='apple-pay-merchant-id']").attr("content");
+        var merchantIdentifier = justEat.applePay.getMerchantIdentifier();
 
         // Determine whether to display the Apple Pay button. See this link for details
         // on the two different approaches: https://developer.apple.com/reference/applepayjs/applepaysession#2168855

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -207,7 +207,7 @@ justEat = {
             error.text(text);
             error.removeClass("hide");
         },
-        showSuccess: function (text) {
+        showSuccess: function () {
             $(".apple-pay-intro").hide();
             var success = $(".apple-pay-success");
             success.removeClass("hide");

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -13,6 +13,9 @@ justEat = {
             var subtotal = $("#amount").val();
             var delivery = "0.01";
             var deliveryTotal = (Number(subtotal) + Number(delivery)).toString();
+
+            var countryCode = $("meta[name='payment-country-code']").attr("content") || "GB";
+            var currencyCode = $("meta[name='payment-currency-code']").attr("content") || "GBP";
             var storeName = $("meta[name='apple-pay-store-name']").attr("content");
 
             var totalForCollection = {
@@ -36,8 +39,8 @@ justEat = {
 
             // Create the Apple Pay payment request as appropriate.
             var paymentRequest = {
-                countryCode: "GB",
-                currencyCode: "GBP",
+                countryCode: countryCode,
+                currencyCode: currencyCode,
                 merchantCapabilities: [ "supports3DS" ],
                 supportedNetworks: [ "amex", "masterCard", "visa" ],
                 lineItems: lineItemsForDelivery,

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -311,7 +311,7 @@ namespace justEat {
          * @returns Whether Apple Pay is supported.
          */
         private supportedByDevice(): boolean {
-            return "ApplePaySession" in Window;
+            return "ApplePaySession" in window;
         }
 
         /**

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -21,7 +21,7 @@ namespace justEat {
             this.merchantIdentifier = $("meta[name='apple-pay-merchant-id']").attr("content");
 
             // Set the Apple Pay JS version to use
-            this.applePayVersion = 1;
+            this.applePayVersion = 2;
         }
 
         /**
@@ -89,7 +89,7 @@ namespace justEat {
                 countryCode: "GB",
                 currencyCode: "GBP",
                 merchantCapabilities: ["supports3DS"],
-                supportedNetworks: ["amex", "masterCard", "visa"],
+                supportedNetworks: ["amex", "discover", "jcb", "masterCard", "privateLabel", "visa"],
                 lineItems: lineItemsForDelivery,
                 total: totalForDelivery,
                 requiredBillingContactFields: ["email", "name", "phone", "postalAddress"],
@@ -102,7 +102,7 @@ namespace justEat {
             };
 
             // Create the Apple Pay session.
-            let session = new ApplePaySession(1, paymentRequest);
+            let session = new ApplePaySession(this.applePayVersion, paymentRequest);
 
             // Setup handler for validation the merchant session.
             session.onvalidatemerchant = function (event) {

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -102,7 +102,7 @@ namespace justEat {
             };
 
             // Create the Apple Pay session.
-            let session = new ApplePayJS.ApplePaySession(1, paymentRequest);
+            let session = new ApplePaySession(1, paymentRequest);
 
             // Setup handler for validation the merchant session.
             session.onvalidatemerchant = function (event) {
@@ -147,7 +147,7 @@ namespace justEat {
                     newLineItems = lineItemsForDelivery;
                 }
 
-                session.completeShippingMethodSelection(ApplePayJS.ApplePaySession.STATUS_SUCCESS, newTotal, newLineItems);
+                session.completeShippingMethodSelection(ApplePaySession.STATUS_SUCCESS, newTotal, newLineItems);
             };
 
             // Setup handler to receive the token when payment is authorized.
@@ -205,7 +205,7 @@ namespace justEat {
                 // Do something with the payment to capture funds and
                 // then dismiss the Apple Pay sheet for the session with
                 // the relevant status code for the payment's authorization.
-                session.completePayment(ApplePayJS.ApplePaySession.STATUS_SUCCESS);
+                session.completePayment(ApplePaySession.STATUS_SUCCESS);
 
                 this.showSuccess();
             };
@@ -219,7 +219,7 @@ namespace justEat {
          * @returns true if the device supports making payments with Apple Pay; otherwise, false.
          */
         private canMakePayments(): boolean {
-            return ApplePayJS.ApplePaySession.canMakePayments();
+            return ApplePaySession.canMakePayments();
         }
 
         /**
@@ -227,7 +227,7 @@ namespace justEat {
          * @returns true if the device supports Apple Pay and there is at least one active card in Wallet; otherwise, false.
          */
         private canMakePaymentsWithActiveCard(): Promise<boolean> {
-            return ApplePayJS.ApplePaySession.canMakePaymentsWithActiveCard(this.merchantIdentifier);
+            return ApplePaySession.canMakePaymentsWithActiveCard(this.merchantIdentifier);
         }
 
         /**
@@ -248,7 +248,7 @@ namespace justEat {
         }
 
         private setupApplePay = (): Promise<boolean> => {
-            return ApplePayJS.ApplePaySession.openPaymentSetup(this.merchantIdentifier)
+            return ApplePaySession.openPaymentSetup(this.merchantIdentifier)
                 .then((success) => {
                     if (success) {
                         this.hideSetupButton();
@@ -319,7 +319,7 @@ namespace justEat {
          * @returns Whether setting up Apple Pay is supported.
          */
         private supportsSetup(): boolean {
-            return "openPaymentSetup" in ApplePayJS.ApplePaySession;
+            return "openPaymentSetup" in ApplePaySession;
         }
     }
 }

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -15,6 +15,7 @@ namespace justEat {
         private countryCode: string;
         private currencyCode: string;
         private session: ApplePaySession;
+        private validationResource: string;
 
         /**
          * Initializes a new instance of the justEat.ApplePay class.
@@ -24,6 +25,9 @@ namespace justEat {
             // Get the merchant identifier and store display name from the page meta tags.
             this.merchantIdentifier = $("meta[name='apple-pay-merchant-id']").attr("content");
             this.storeName = $("meta[name='apple-pay-store-name']").attr("content");
+
+            // Get the URL to POST to for Apple Pay merchant validation
+            this.validationResource = $("link[rel='merchant-validation']").attr("href");
 
             // Set the Apple Pay JS version to use
             this.applePayVersion = 2;
@@ -284,15 +288,15 @@ namespace justEat {
          * @param data - The request data.
          * @param headers - The request headers.
          */
-        private createValidationRequest(data: any, headers: any): JQueryAjaxSettings {
+        private createValidationRequest = (data: any, headers: any): JQueryAjaxSettings => {
             return {
-                url: "/home/validate",
+                url: this.validationResource,
                 method: "POST",
                 contentType: "application/json; charset=utf-8",
                 data: JSON.stringify(data),
                 headers: headers
             };
-        };
+        }
 
         /**
          * Event handler for setting up Apple Pay.

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -1,0 +1,330 @@
+﻿// Copyright (c) Just Eat, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace justEat {
+
+    /**
+     * A class representing the handler for Apple Pay JS.
+     */
+    export class ApplePay {
+
+        public merchantIdentifier: string;
+
+        private applePayVersion: number;
+
+        /**
+         * Initializes a new instance of the justEat.ApplePay class.
+         */
+        public constructor() {
+
+            // Get the merchant identifier from the page meta tags.
+            this.merchantIdentifier = $("meta[name='apple-pay-merchant-id']").attr("content");
+
+            // Set the Apple Pay JS version to use
+            this.applePayVersion = 1;
+        }
+
+        /**
+         * Initializes the handler for the current page.
+         */
+        public initialize(): void {
+
+            // Is ApplePaySession available in the browser?
+            if (this.supportedByDevice() === true) {
+
+                // Determine whether to display the Apple Pay button. See this link for details
+                // on the two different approaches: https://developer.apple.com/reference/applepayjs/applepaysession#2168855
+                if (this.canMakePayments() === true) {
+                    this.showButton();
+                } else {
+                    this.canMakePaymentsWithActiveCard().then((canMakePayments: boolean) => {
+                        if (canMakePayments === true) {
+                            this.showButton();
+                        } else {
+                            if (this.supportsSetup()) {
+                                this.showSetupButton();
+                            } else {
+                                this.showError("Apple Pay cannot be used at this time. If using macOS Sierra you need to be paired with a device that supports TouchID.");
+                            }
+                        }
+                    });
+                }
+            } else {
+                this.showError("This device and/or browser does not support Apple Pay.");
+            }
+        }
+
+        private beginPayment = (e: JQueryEventObject): void => {
+
+            e.preventDefault();
+
+            // Get the amount to request from the form and set up
+            // the totals and line items for collection and delivery.
+            let subtotal = $("#amount").val();
+            let delivery = "0.01";
+            let deliveryTotal = (parseFloat(subtotal) + parseFloat(delivery)).toString(10);
+            let storeName = $("meta[name='apple-pay-store-name']").attr("content");
+
+            let totalForCollection = {
+                label: storeName,
+                amount: subtotal
+            };
+
+            let lineItemsForCollection = [
+                { label: "Subtotal", amount: subtotal, type: "final" }
+            ];
+
+            let totalForDelivery = {
+                label: storeName,
+                amount: deliveryTotal
+            };
+
+            let lineItemsForDelivery = [
+                { label: "Subtotal", amount: subtotal, type: "final" },
+                { label: "Delivery", amount: delivery, type: "final" }
+            ];
+
+            // Create the Apple Pay payment request as appropriate.
+            let paymentRequest = {
+                countryCode: "GB",
+                currencyCode: "GBP",
+                merchantCapabilities: ["supports3DS"],
+                supportedNetworks: ["amex", "masterCard", "visa"],
+                lineItems: lineItemsForDelivery,
+                total: totalForDelivery,
+                requiredBillingContactFields: ["email", "name", "phone", "postalAddress"],
+                requiredShippingContactFields: ["email", "name", "phone", "postalAddress"],
+                shippingType: "delivery",
+                shippingMethods: [
+                    { label: "Delivery", amount: delivery, identifier: "delivery", detail: "Delivery to you" },
+                    { label: "Collection", amount: "0.00", identifier: "collection", detail: "Collect from the store" }
+                ]
+            };
+
+            // Create the Apple Pay session.
+            let session = new ApplePayJS.ApplePaySession(1, paymentRequest);
+
+            // Setup handler for validation the merchant session.
+            session.onvalidatemerchant = function (event) {
+
+                // Create the payload.
+                let data = {
+                    validationUrl: event.validationURL
+                };
+
+                // Setup antiforgery HTTP header.
+                let antiforgeryHeader = $("meta[name='x-antiforgery-name']").attr("content");
+                let antiforgeryToken = $("meta[name='x-antiforgery-token']").attr("content");
+
+                let headers: any = {};
+                headers[antiforgeryHeader] = antiforgeryToken;
+
+                // Post the payload to the server to validate the
+                // merchant session using the merchant certificate.
+                $.ajax({
+                    url: "/home/validate",
+                    method: "POST",
+                    contentType: "application/json; charset=utf-8",
+                    data: JSON.stringify(data),
+                    headers: headers
+                }).then((merchantSession) => {
+                    // Complete validation by passing the merchant session to the Apple Pay session.
+                    session.completeMerchantValidation(merchantSession);
+                });
+            };
+
+            // Setup handler for shipping method selection.
+            session.onshippingmethodselected = (event) => {
+
+                let newTotal;
+                let newLineItems;
+
+                if (event.shippingMethod.identifier === "collection") {
+                    newTotal = totalForCollection;
+                    newLineItems = lineItemsForCollection;
+                } else {
+                    newTotal = totalForDelivery;
+                    newLineItems = lineItemsForDelivery;
+                }
+
+                session.completeShippingMethodSelection(ApplePayJS.ApplePaySession.STATUS_SUCCESS, newTotal, newLineItems);
+            };
+
+            // Setup handler to receive the token when payment is authorized.
+            session.onpaymentauthorized = (event) => {
+
+                // Get the contact details for use, for example to
+                // use to create an account for the user.
+                let billingContact = event.payment.billingContact;
+                let shippingContact = event.payment.shippingContact;
+
+                // Get the payment data for use to capture funds from
+                // the encrypted Apple Pay token in your server.
+                let token = event.payment.token.paymentData;
+
+                // Apply the details from the Apple Pay sheet to the page.
+                let update = (panel: JQuery, contact: ApplePayJS.ApplePayPaymentContact) => {
+
+                    if (contact.emailAddress) {
+                        panel.find(".contact-email")
+                            .text(contact.emailAddress)
+                            .attr("href", "mailto:" + contact.emailAddress)
+                            .append("<br/>")
+                            .removeClass("hide");
+                    }
+
+                    if (contact.emailAddress) {
+                        panel.find(".contact-telephone")
+                            .text(contact.phoneNumber)
+                            .attr("href", "tel:" + contact.phoneNumber)
+                            .append("<br/>")
+                            .removeClass("hide");
+                    }
+
+                    if (contact.givenName) {
+                        panel.find(".contact-name")
+                            .text(contact.givenName + " " + contact.familyName)
+                            .append("<br/>")
+                            .removeClass("hide");
+                    }
+
+                    if (contact.addressLines) {
+                        panel.find(".contact-address-lines").text(contact.addressLines.join(", "));
+                        panel.find(".contact-locality").text(contact.locality);
+                        panel.find(".contact-administrative-area").text(contact.administrativeArea);
+                        panel.find(".contact-postal-code").text(contact.postalCode);
+                        panel.find(".contact-country").text(contact.country);
+                        panel.find(".contact-address").removeClass("hide");
+                    }
+                };
+
+                $(".card-name").text(event.payment.token.paymentMethod.displayName);
+                update($("#billing-contact"), billingContact);
+                update($("#shipping-contact"), shippingContact);
+
+                // Do something with the payment to capture funds and
+                // then dismiss the Apple Pay sheet for the session with
+                // the relevant status code for the payment's authorization.
+                session.completePayment(ApplePayJS.ApplePaySession.STATUS_SUCCESS);
+
+                this.showSuccess();
+            };
+
+            // Start the session to display the Apple Pay sheet.
+            session.begin();
+        }
+
+        /**
+         * Indicates whether or not the device supports Apple Pay.
+         * @returns true if the device supports making payments with Apple Pay; otherwise, false.
+         */
+        private canMakePayments(): boolean {
+            return ApplePayJS.ApplePaySession.canMakePayments();
+        }
+
+        /**
+         * Indicates whether or not the device supports Apple Pay and if the user has an active card in Wallet.
+         * @returns true if the device supports Apple Pay and there is at least one active card in Wallet; otherwise, false.
+         */
+        private canMakePaymentsWithActiveCard(): Promise<boolean> {
+            return ApplePayJS.ApplePaySession.canMakePaymentsWithActiveCard(this.merchantIdentifier);
+        }
+
+        /**
+         * Gets the current page's language.
+         * @returns The current page language.
+         */
+        private getPageLanguage(): string {
+            return $("html").attr("lang") || "en";
+        }
+
+        /**
+         * Hides the setup button.
+         */
+        private hideSetupButton(): void {
+            let button = $("#set-up-apple-pay-button");
+            button.addClass("hide");
+            button.off("click");
+        }
+
+        private setupApplePay = (): Promise<boolean> => {
+            return ApplePayJS.ApplePaySession.openPaymentSetup(this.merchantIdentifier)
+                .then((success) => {
+                    if (success) {
+                        this.hideSetupButton();
+                        this.showButton();
+                    } else {
+                        this.showError("Failed to set up Apple Pay.");
+                    }
+                    return success;
+                }).catch((e: any) => {
+                    this.showError("Failed to set up Apple Pay. " + e);
+                    return false;
+                });
+        }
+
+        private showButton = (): void => {
+
+            let button = $("#apple-pay-button");
+            button.attr("lang", this.getPageLanguage());
+            button.on("click", this.beginPayment);
+
+            if (this.supportsSetup()) {
+                button.addClass("apple-pay-button-with-text");
+                button.addClass("apple-pay-button-black-with-text");
+            } else {
+                button.addClass("apple-pay-button");
+                button.addClass("apple-pay-button-black");
+            }
+
+            button.removeClass("hide");
+        }
+
+        /**
+         * Shows the error banner.
+         * @param text - The text to show in the banner.
+         */
+        private showError(text: string): void {
+            let error = $(".apple-pay-error");
+            error.text(text);
+            error.removeClass("hide");
+        }
+
+        private showSetupButton = (): void => {
+            let button = $("#set-up-apple-pay-button");
+            button.attr("lang", this.getPageLanguage());
+            button.on("click", this.setupApplePay);
+            button.removeClass("hide");
+        }
+
+        /**
+         * Shows the successful payment button.
+         */
+        private showSuccess() {
+            $(".apple-pay-intro").hide();
+            let success = $(".apple-pay-success");
+            success.removeClass("hide");
+        }
+
+        /**
+         * Returns whether Apple Pay is supported on the current device.
+         * @returns Whether Apple Pay is supported.
+         */
+        private supportedByDevice(): boolean {
+            return "ApplePaySession" in Window;
+        }
+
+        /**
+         * Returns whether setting up Apple Pay is supported on the current device.
+         * @returns Whether setting up Apple Pay is supported.
+         */
+        private supportsSetup(): boolean {
+            return "openPaymentSetup" in ApplePayJS.ApplePaySession;
+        }
+    }
+}
+
+(() => {
+    const handler = new justEat.ApplePay();
+    handler.initialize();
+})();

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -311,7 +311,7 @@ namespace justEat {
          * @returns Whether Apple Pay is supported.
          */
         private supportedByDevice(): boolean {
-            return "ApplePaySession" in window;
+            return "ApplePaySession" in window && ApplePaySession !== undefined;
         }
 
         /**

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -33,8 +33,8 @@ namespace justEat {
             this.applePayVersion = 2;
 
             // Set the appropriate ISO country and currency codes
-            this.countryCode = "GB";
-            this.currencyCode = "GBP";
+            this.countryCode = $("meta[name='payment-country-code']").attr("content") || "GB";
+            this.currencyCode = $("meta[name='payment-currency-code']").attr("content") || "GBP";
         }
 
         /**


### PR DESCRIPTION
This PR improves the sample with the following features:

  1. Adds a sample TypeScript implementation of Apple Pay JS using [```@types/applepayjs```](https://www.npmjs.com/package/@types/applepayjs) using Apple Pay JS version 2.
  1. Adds a polyfill for testing on devices that do not support Apple Pay JS using [justeat/applepayjs-polyfill](https://github.com/justeat/applepayjs-polyfill).
  1. Adds example CSS for a "Donate with Apple Pay" button.
  1. Fixes the example code for setting up Apple Pay on the device not working correctly.
  1. Adds support for dynamically changing the country/currency via the ```lang``` query string parameter.
  1. Updates the README to note that bower, npm and NuGet packages need to be restored.