### PR TITLE
Handle no merchant certificate available

### DIFF
--- a/src/ApplePayJS/Controllers/HomeController.cs
+++ b/src/ApplePayJS/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Just Eat, 2016. All rights reserved.
+// Copyright (c) Just Eat, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace JustEat.ApplePayJS.Controllers
@@ -147,8 +147,15 @@ namespace JustEat.ApplePayJS.Controllers
 
         private string GetMerchantIdentifier()
         {
-            var merchantCertificate = LoadMerchantCertificate();
-            return GetMerchantIdentifier(merchantCertificate);
+            try
+            {
+                var merchantCertificate = LoadMerchantCertificate();
+                return GetMerchantIdentifier(merchantCertificate);
+            }
+            catch (InvalidOperationException)
+            {
+                return string.Empty;
+            }
         }
 
         private string GetMerchantIdentifier(X509Certificate2 certificate)

--- a/src/ApplePayJS/wwwroot/js/site.js
+++ b/src/ApplePayJS/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Just Eat, 2016. All rights reserved.
+// Copyright (c) Just Eat, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 justEat = {
@@ -233,11 +233,14 @@ justEat = {
 
 (function () {
 
-    // Is ApplePaySession available in the browser?
-    if (justEat.applePay.supportedByDevice()) {
+    // Get the merchant identifier from the page meta tags.
+    var merchantIdentifier = justEat.applePay.getMerchantIdentifier();
 
-        // Get the merchant identifier from the page meta tags.
-        var merchantIdentifier = justEat.applePay.getMerchantIdentifier();
+    if (!merchantIdentifier) {
+        justEat.applePay.showError("No Apple Pay merchant certificate is configured.");
+    }
+    // Is ApplePaySession available in the browser?
+    else if (justEat.applePay.supportedByDevice()) {
 
         // Determine whether to display the Apple Pay button. See this link for details
         // on the two different approaches: https://developer.apple.com/reference/applepayjs/applepaysession#2168855

--- a/src/ApplePayJS/wwwroot/ts/site.ts
+++ b/src/ApplePayJS/wwwroot/ts/site.ts
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Just Eat, 2016. All rights reserved.
+// Copyright (c) Just Eat, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace justEat {
@@ -42,8 +42,11 @@ namespace justEat {
          */
         public initialize(): void {
 
+            if (!this.merchantIdentifier) {
+                this.showError("No Apple Pay merchant certificate is configured.");
+            }
             // Is ApplePaySession available in the browser?
-            if (this.supportedByDevice() === true) {
+            else if (this.supportedByDevice() === true) {
 
                 // Determine whether to display the Apple Pay button. See this link for details
                 // on the two different approaches: https://developer.apple.com/reference/applepayjs/applepaysession#2168855


### PR DESCRIPTION
Gracefully handle there being no Apple Pay merchant certificate being configured in the UI.