### PR TITLE
Fix content not being served from the .well-known folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ packages
 project.lock.json
 PublishProfiles
 src/ApplePayJS/*.pfx
-src/ApplePayJS/wwwroot/.well-known/*
+src/ApplePayJS/wwwroot/.well-known/apple-developer-merchantid-domain-association
 src/ApplePayJS/wwwroot/**/*.min.css
 src/ApplePayJS/wwwroot/**/*.min.js
 src/ApplePayJS/wwwroot/ts/*.js

--- a/src/ApplePayJS/Startup.cs
+++ b/src/ApplePayJS/Startup.cs
@@ -75,7 +75,11 @@ namespace JustEat.ApplePayJS
                    .UseStatusCodePages();
             }
 
-            app.UseStaticFiles();
+            app.UseStaticFiles(
+                new StaticFileOptions()
+                {
+                    ServeUnknownFileTypes = true, // Required to serve the files in the .well-known folder
+                });
 
             app.UseMvc(routes =>
             {

--- a/src/ApplePayJS/wwwroot/.well-known/apple-app-site-association
+++ b/src/ApplePayJS/wwwroot/.well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+﻿{
+  "activitycontinuation": {
+    "apps": []
+  },
+  "applinks": {
+    "apps": [],
+    "details": []
+  },
+  "spotlight-image-search": {
+    "details": []
+  }
+}


### PR DESCRIPTION
  * Fix content effectively not being served from the `.well-known` folder, as the files that would be placed there are typically extensionless, so aren't served by default.
  * Add a default/empty `apple-app-site-association file`.