### PR TITLE
Force TLS 1.2

### DIFF
--- a/src/ApplePayJS/Controllers/HomeController.cs
+++ b/src/ApplePayJS/Controllers/HomeController.cs
@@ -39,6 +39,9 @@ namespace JustEat.ApplePayJS.Controllers
         [Route("applepay/validate", Name = "MerchantValidation")]
         public async Task<IActionResult> Validate([FromBody] ValidateMerchantSessionModel model)
         {
+            // You may wish to additionally validate that the URI specified for merchant validation in the
+            // request body is a documented Apple Pay JS hostname. The IP addresses and DNS hostnames of
+            // these servers are available here: https://developer.apple.com/documentation/applepayjs/setting_up_server_requirements
             if (!ModelState.IsValid ||
                 string.IsNullOrWhiteSpace(model?.ValidationUrl) ||
                 !Uri.TryCreate(model.ValidationUrl, UriKind.Absolute, out Uri requestUri))

--- a/src/ApplePayJS/Controllers/HomeController.cs
+++ b/src/ApplePayJS/Controllers/HomeController.cs
@@ -5,6 +5,7 @@ namespace JustEat.ApplePayJS.Controllers
 {
     using System;
     using System.Net.Http;
+    using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Threading.Tasks;
@@ -94,6 +95,10 @@ namespace JustEat.ApplePayJS.Controllers
         {
             var handler = new HttpClientHandler();
             handler.ClientCertificates.Add(certificate);
+
+            // Apple Pay JS requires the use of TLS 1.2 to generate a merchange session:
+            // https://developer.apple.com/documentation/applepayjs/setting_up_server_requirements
+            handler.SslProtocols = SslProtocols.Tls12;
 
             return new HttpClient(handler, disposeHandler: true);
         }


### PR DESCRIPTION
I stumbled upon [this article](https://codedump.io/share/65J945bc3asl/1) where a user of the sample code had an issue using it with .NET 4.6 because TLS 1.2 is not explicitly enabled there, or with `HttpClient`.

This PR explicitly sets the `HttpClientHandler.SslProtocols` property to `SslProtocols.Tls12` to make this requirement more obvious in the sample code.

Also adds a comment the integrators may wish to white list the Apple Pay JS hostnames used for merchant validation.