### PR TITLE
Support Apple Pay JS version 3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-﻿os: Visual Studio 2017
-version: 2.0.{build}
+os: Visual Studio 2017
+version: 3.0.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,6 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "1.0.4" --install-dir "$DOTNET_INSTALL_DIR"
     curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 

--- a/src/ApplePayJS/ApplePayJS.csproj
+++ b/src/ApplePayJS/ApplePayJS.csproj
@@ -20,7 +20,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <UserSecretsId>JustEat.ApplePayJS</UserSecretsId>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ApplePayJS/Views/Home/Index.cshtml
+++ b/src/ApplePayJS/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
     Copyright (c) Just Eat, 2016. All rights reserved.
     Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 *@
@@ -101,7 +101,9 @@
                             <div class="contact-address hide">
                                 <hr />
                                 <span class="contact-address-lines"></span><br />
+                                <span class="contact-sub-locality"></span><br />
                                 <span class="contact-locality"></span><br />
+                                <span class="contact-sub-administrative-area"></span><br />
                                 <span class="contact-administrative-area"></span><br />
                                 <span class="contact-postal-code"></span><br />
                                 <span class="contact-country"></span><br />
@@ -119,7 +121,9 @@
                             <div class="contact-address hide">
                                 <hr />
                                 <span class="contact-address-lines"></span><br />
+                                <span class="contact-sub-locality"></span><br />
                                 <span class="contact-locality"></span><br />
+                                <span class="contact-sub-administrative-area"></span><br />
                                 <span class="contact-administrative-area"></span><br />
                                 <span class="contact-postal-code"></span><br />
                                 <span class="contact-country"></span><br />

--- a/src/ApplePayJS/Views/Home/_Polyfill.cshtml
+++ b/src/ApplePayJS/Views/Home/_Polyfill.cshtml
@@ -1,4 +1,4 @@
-﻿@model string
+@model string
 @*
     Use this polyfill during development to test your Apple Pay JS implementation
     on devices and browsers that do not natively support Apple Pay.
@@ -16,10 +16,14 @@
                 emailAddress: "user@domain.com",
                 familyName: "Smith",
                 givenName: "John",
+                phoneticFamilyName: "Smith",
+                phoneticGivenName: "John",
                 phoneNumber: "07777777777",
                 addressLines: ["Just Eat", "Fleet Place House", "2 Fleet Place"],
                 locality: "London",
+                subLocality: "",
                 administrativeArea: "",
+                subAdministrativeArea: "",
                 postalCode: "EC4M 7RF",
                 country: "United Kingdom",
                 countryCode: "GB"

--- a/src/ApplePayJS/bower.json
+++ b/src/ApplePayJS/bower.json
@@ -2,6 +2,6 @@
   "name": "justeatapplepayjs",
   "private": true,
   "dependencies": {
-    "applepayjs-polyfill": "2.0.0"
+    "applepayjs-polyfill": "3.0.0"
   }
 }

--- a/src/ApplePayJS/package-lock.json
+++ b/src/ApplePayJS/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "justeatapplepayjs",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/applepayjs": {
-      "version": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-1.0.0.tgz",
-      "integrity": "sha1-RQsmagUkQmRJtg0gqgk1g4hPBoY=",
+      "version": "3.0.0",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/@types/applepayjs/-/applepayjs-3.0.0.tgz",
+      "integrity": "sha512-Sh0UvKsrNK1sdNi+niFTL/QZHFcTQzecX+38ZiZfdognOU31txfHn9bTUb8OW20hgbWm1hRCzi1yiCPMBgApbg==",
       "dev": true
     },
     "@types/jquery": {

--- a/src/ApplePayJS/package-lock.json
+++ b/src/ApplePayJS/package-lock.json
@@ -671,8 +671,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz",
-      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "unique-string": {

--- a/src/ApplePayJS/package.json
+++ b/src/ApplePayJS/package.json
@@ -6,7 +6,7 @@
     "@types/applepayjs": "1.0.0",
     "@types/jquery": "2.0.41",
     "tslint": "4.5.1",
-    "typescript": "2.2.1"
+    "typescript": "2.6.1"
   },
   "scripts": {
     "build": "tsc",

--- a/src/ApplePayJS/package.json
+++ b/src/ApplePayJS/package.json
@@ -1,9 +1,9 @@
 {
   "name": "justeatapplepayjs",
   "private": true,
-  "version": "2.0.0",
+  "version": "3.0.0",
   "devDependencies": {
-    "@types/applepayjs": "1.0.0",
+    "@types/applepayjs": "3.0.0",
     "@types/jquery": "2.0.41",
     "tslint": "4.5.1",
     "typescript": "2.6.1"


### PR DESCRIPTION
  1. Update the samples to support Apple Pay JS version 3.
  1. Fix `completePayment()` not being called if a payment was not "authorized".
  1. Fix incorrect variable being used to display the user's telephone number.
  1. Update to TypeScript 2.6.1.
  1. Update dead-link to Apple's documentation.