### PR TITLE
Fix apple-app-site-association not being published

### DIFF
--- a/src/ApplePayJS/ApplePayJS.csproj
+++ b/src/ApplePayJS/ApplePayJS.csproj
@@ -37,6 +37,7 @@
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
+      <Content Include="wwwroot/.well-known/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes)" />
     </ItemGroup>
   </Target>
   <ItemGroup>


### PR DESCRIPTION
Fix the `/.well-known/apple-app-site-association` file not being published since #22.