### PR TITLE
Update to ASP.NET Core 3.1.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,6 @@ jobs:
       run: ./build.ps1
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_NOLOGO: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         NUGET_XMLDOC_MODE: skip

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
+    "version": "3.1.402",
     "allowPrerelease": false
   }
 }

--- a/tests/ApplePayJS.Tests/ApplePayJS.Tests.csproj
+++ b/tests/ApplePayJS.Tests/ApplePayJS.Tests.csproj
@@ -10,14 +10,14 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="3.0.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="83.0.4103.3910" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="85.0.4183.8700" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="applepay-dev.pfx;testsettings.json;xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
  * Update .NET Core SDK and NuGet packages for ASP.NET Core 3.1.8.
  * Set `DOTNET_NOLOGO` to reduce CI build time and log noise.
