### PR TITLE
 Support base64 encoded certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ You should be able to debug the application in [Visual Studio Code](https://code
 
 If you are deploying the sample application to a Microsoft Azure App Service Web App, you will need to make the following configuration changes to your Web App for the sample application to run correctly:
 
-* Navigate to the _SSL certificates_ tab of your Web App and upload your Apple Merchant certificate as a ```.pfx``` file, making a note of the _THUMBPRINT_ value.
-* Navigate to the _Application settings_ tab of your Web App and add the following settings:
-  * **WEBSITE_LOAD_CERTIFICATES** to the value of _THUMBPRINT_ you noted above.
-  * **ApplePay:MerchantCertificateThumbprint** to the value of _THUMBPRINT_ you noted above.
+* Navigate to the _Private Key Certificates (.pfx)_ tab of your Web App's _TLS/SSL Settings_ blade and upload your Apple Merchant certificate as a `.pfx` file, making a note of the _Thumbprint_ value.
+* Navigate to the _Configuration_ blade of your Web App and add the following settings:
+  * **WEBSITE_LOAD_CERTIFICATES** to the value of _Thumbprint_ you noted above.
+  * **ApplePay:MerchantCertificateThumbprint** to the value of _Thumbprint_ you noted above.
   * **ApplePay:UseCertificateStore** to the value of _true_.
   * Save the changes.
-* Ensure the hostname you are using (either ```{yourappname}.azurewebsites.net``` or a custom hostname that you have set up) has been added in the Apple Developer portal to your merchant Id and you've added the Apple Pay domain validation file as described in the _Setup_ section above.
+* Ensure the hostname you are using (either ```{yourappname}.azurewebsites.net``` or a custom hostname that you have set up) has been added in the Apple Developer portal to your merchant ID and you've added the Apple Pay domain validation file as described in the _Setup_ section above.
 
 ## Feedback
 

--- a/src/ApplePayJS/Clients/MerchantCertificate.cs
+++ b/src/ApplePayJS/Clients/MerchantCertificate.cs
@@ -21,13 +21,17 @@ namespace JustEat.ApplePayJS.Clients
         public X509Certificate2 GetCertificate()
         {
             // Get the merchant certificate for two-way TLS authentication with the Apple Pay server.
-            if (_options.UseCertificateStore)
+            if (!string.IsNullOrWhiteSpace(_options.MerchantCertificate))
             {
-                return LoadCertificateFromStore();
+                return LoadCertificateFromBase64String(_options.MerchantCertificate, _options.MerchantCertificatePassword);
+            }
+            else if (_options.UseCertificateStore)
+            {
+                return LoadCertificateFromStore(_options.MerchantCertificateThumbprint);
             }
             else
             {
-                return LoadCertificateFromDisk();
+                return LoadCertificateFromDisk(_options.MerchantCertificateFileName, _options.MerchantCertificatePassword);
             }
         }
 
@@ -44,7 +48,7 @@ namespace JustEat.ApplePayJS.Clients
             }
         }
 
-        private string GetMerchantIdentifier(X509Certificate2 certificate)
+        private static string GetMerchantIdentifier(X509Certificate2 certificate)
         {
             // This OID returns the ASN.1 encoded merchant identifier
             var extension = certificate.Extensions["1.2.840.113635.100.6.32"];
@@ -55,42 +59,52 @@ namespace JustEat.ApplePayJS.Clients
             }
 
             // Convert the raw ASN.1 data to a string containing the ID
-            return Encoding.ASCII.GetString(extension.RawData).Substring(2);
+            return Encoding.ASCII.GetString(extension.RawData)[2..];
         }
 
-        private X509Certificate2 LoadCertificateFromDisk()
+        private static X509Certificate2 LoadCertificateFromBase64String(string encoded, string? password)
+        {
+            byte[] rawData = Convert.FromBase64String(encoded);
+
+            return X509Certificate2.GetCertContentType(rawData) switch
+            {
+                X509ContentType.Pfx => new X509Certificate2(rawData, password),
+                _ => throw new NotSupportedException("The format of the encoded Apple Pay merchant certificate is not supported."),
+            };
+        }
+
+        private static X509Certificate2 LoadCertificateFromDisk(string? fileName, string? password)
         {
             try
             {
                 return new X509Certificate2(
-                    _options.MerchantCertificateFileName ?? string.Empty,
-                    _options.MerchantCertificatePassword);
+                    fileName ?? string.Empty,
+                    password);
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"Failed to load Apple Pay merchant certificate file from '{_options.MerchantCertificateFileName}'.", ex);
+                throw new InvalidOperationException($"Failed to load Apple Pay merchant certificate file from '{fileName}'.", ex);
             }
         }
 
-        private X509Certificate2 LoadCertificateFromStore()
+        private static X509Certificate2 LoadCertificateFromStore(string? thumbprint)
         {
             // Load the certificate from the current user's certificate store. This
             // is useful if you do not want to publish the merchant certificate with
             // your application, but it is also required to be able to use an X.509
             // certificate with a private key if the user profile is not available,
             // such as when using IIS hosting in an environment such as Microsoft Azure.
-            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-            store.Open(OpenFlags.ReadOnly);
+            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadOnly);
 
             var certificates = store.Certificates.Find(
                 X509FindType.FindByThumbprint,
-                _options.MerchantCertificateThumbprint?.Trim() ?? string.Empty,
+                thumbprint?.Trim() ?? string.Empty,
                 validOnly: false);
 
             if (certificates.Count < 1)
             {
                 throw new InvalidOperationException(
-                    $"Could not find Apple Pay merchant certificate with thumbprint '{_options.MerchantCertificateThumbprint}' from store '{store.Name}' in location '{store.Location}'.");
+                    $"Could not find Apple Pay merchant certificate with thumbprint '{thumbprint}' from store '{store.Name}' in location '{store.Location}'.");
             }
 
             return certificates[0];

--- a/src/ApplePayJS/Models/ApplePayOptions.cs
+++ b/src/ApplePayJS/Models/ApplePayOptions.cs
@@ -9,6 +9,8 @@ namespace JustEat.ApplePayJS.Models
 
         public bool UseCertificateStore { get; set; }
 
+        public string? MerchantCertificate { get; set; }
+
         public string? MerchantCertificateFileName { get; set; }
 
         public string? MerchantCertificatePassword { get; set; }

--- a/src/ApplePayJS/appsettings.json
+++ b/src/ApplePayJS/appsettings.json
@@ -3,6 +3,7 @@
     "DefaultLanguage": "en-GB",
     "StoreName": "Just Eat",
     "UseCertificateStore": false,
+    "MerchantCertificate": "",
     "MerchantCertificateFileName": "",
     "MerchantCertificatePassword": "",
     "MerchantCertificateThumbprint": "",


### PR DESCRIPTION
Support loading the merchant certificate from a base64 encoded application setting.

This supports scenarios such as Azure Key Vault.
