### PR TITLE
Remove DOTNET_ROLL_FORWARD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  DOTNET_ROLL_FORWARD: Major # HACK Remove once Playwright supports .NET 6
-
 jobs:
   build:
     name: ${{ matrix.os }}


### PR DESCRIPTION
Remove `DOTNET_ROLL_FORWARD` as Playwright now supports .NET 6.
